### PR TITLE
Finds Kakao id and Phone number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,63 @@
 *.csv
 .env
+
+### Python ###
+*.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+

--- a/scraper.rb
+++ b/scraper.rb
@@ -67,11 +67,13 @@ module Scraper
         end
 
         ptags = doc.xpath('//p')
+        kakao_ptags = ''
         for p in ptags
           if p.text =~ /[톡]/
-            study_info.kakao_ptag = p.text
+            kakao_ptags += p.text
           end
         end
+        study_info.kakao_ptag = kakao_ptags
 
         study_infos << study_info
         p study_info.to_a.to_s

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,7 +16,7 @@ KAKAO_REGEX = /카{0,2}+오?+톡[\s]?[아]?[이]?[디]?[i]?[d]?[\s]?+[:]?[\s]?+(
 
 StudyInfo = Struct.new(:host, :link, :study_name, :contact, :date, :kakao, :kakao_ptag, :phone) do
   def to_a
-    [host, link, study_name, contact, date, kakao, kakao_ptag phone]
+    [host, link, study_name, contact, date, kakao, kakao_ptag, phone]
   end
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -69,7 +69,7 @@ module Scraper
         ptags = doc.xpath('//p')
         for p in ptags
           if p.text =~ /[톡]/
-            p p.text
+            study_info.kakao_ptag = p.text
           end
         end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -11,10 +11,12 @@ Capybara.default_driver = :selenium
 Capybara.default_wait_time = 5
 
 EMAIL_REGEX = /[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+/i
+PHONE_REGEX = /(010[ .-]?[0-9]{4}+[ .-]?[0-9]{4}+)/
+KAKAO_REGEX = /카{0,2}+오?+톡[\s]?[아]?[이]?[디]?[i]?[d]?[\s]?+[:]?[\s]?+([\w]+)/
 
-StudyInfo = Struct.new(:host, :link, :study_name, :contact, :date) do
+StudyInfo = Struct.new(:host, :link, :study_name, :contact, :date, :kakao, :kakao_ptag, :phone) do
   def to_a
-    [host, link, study_name, contact, date]
+    [host, link, study_name, contact, date, kakao, kakao_ptag phone]
   end
 end
 
@@ -44,19 +46,37 @@ module Scraper
       within_frame(main_frame) do
         text = page.text
 
+        doc = Nokogiri::HTML(page.html)
+        table = doc.xpath('//table').text
+        text = text + table
+
+        study_info = StudyInfo.new
+        study_info.host = host
+        study_info.link = link
+        study_info.study_name = study_name
+        study_info.date = find('div.tit-box > div.fr > table > tbody > tr > td.m-tcol-c.date').text
+
         if text =~ EMAIL_REGEX
-          study_info = StudyInfo.new
           study_info.contact = text.match(EMAIL_REGEX).to_s
-          study_info.host = host
-          study_info.link = link
-          study_info.study_name = study_name
-          study_info.date = find('div.tit-box > div.fr > table > tbody > tr > td.m-tcol-c.date').text
-
-          study_infos << study_info
-          p study_info.to_a.to_s
-
-          write_info study_info
         end
+        if text =~ PHONE_REGEX
+          study_info.phone = text.match(PHONE_REGEX).to_s
+        end
+        if text =~ KAKAO_REGEX
+          study_info.kakao = text.match(KAKAO_REGEX).to_s
+        end
+
+        ptags = doc.xpath('//p')
+        for p in ptags
+          if p.text =~ /[톡]/
+            p p.text
+          end
+        end
+
+        study_infos << study_info
+        p study_info.to_a.to_s
+
+        write_info study_info
       end
     end
 
@@ -88,9 +108,9 @@ module Scraper
       visit host
       login
 
-      pages = 1..20
+      pages = 1..60
       pages.each do |page|
-        link = "http://cafe.naver.com/ArticleList.nhn?search.boardtype=L&search.menuid=1205&search.questionTab=A&search.clubid=15754634&search.totalCount=151&search.page=#{page}"
+        link = "http://cafe.naver.com/ArticleList.nhn?search.boardtype=L&search.menuid=600&search.questionTab=A&search.clubid=16996348&search.totalCount=151&search.page=#{page}"
         get_article_links link
       end
     end


### PR DESCRIPTION
``` ruby
table = doc.xpath('//table').text
text = text + table
```

독취사 카페에서 표 형식으로 글을 올리는데 원래는 이걸 못잡았던걸 잡도록 했습니다

``` ruby
PHONE_REGEX = /(010[ .-]?[0-9]{4}+[ .-]?[0-9]{4}+)/
KAKAO_REGEX = /카{0,2}+오?+톡[\s]?[아]?[이]?[디]?[i]?[d]?[\s]?+[:]?[\s]?+([\w]+)/
```

카카오 정규식은 좀 볼품없군요..

``` ruby
ptags = doc.xpath('//p')
for p in ptags
      if p.text =~ /[톡]/
        study_info.kakao_ptag = p.text
      end
end
```

저렇게 해도 못잡는 부분들이 있길래 '톡'이라는 글자가 들어가는 부분은 그냥 한줄 전체를 뽑도록 했습니다.
